### PR TITLE
[FIX] 연관 상품 버그 수정

### DIFF
--- a/front-end/src/components/Details/Content/RelatedProduct/index.jsx
+++ b/front-end/src/components/Details/Content/RelatedProduct/index.jsx
@@ -54,8 +54,8 @@ function RelatedProduct() {
       </S.Button>
       {data &&
         visibleData.map((product) => (
-          <S.ImageContainer key={product.productId}>
-            <S.StyledLink to={`${BROWSER_PATH.DETAILS}/${product.productId}`}>
+          <S.ImageContainer key={product.id}>
+            <S.StyledLink to={`${BROWSER_PATH.DETAILS}/${product.id}`}>
               <S.Image src={product.image} alt="carousel-thumbnail" />
               <S.Text>
                 {product.name}


### PR DESCRIPTION
# 개요

#32 
기존에는 `productId`로 작성하였는데 서버에서 넘어오는 데이터는 `id`로 되어있어서 해당 버그를 수정하였다

## 한 일

- `React` 수정
