### PR TITLE
[FE] 상품 상세페이지 UI 수정

### DIFF
--- a/front-end/src/components/Details/Content/RelatedProduct/index.jsx
+++ b/front-end/src/components/Details/Content/RelatedProduct/index.jsx
@@ -27,7 +27,7 @@ function RelatedProduct() {
   }, [relatedProductsRequest]);
 
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [numVisible] = useState(4);
+  const [numVisible] = useState(3);
 
   const handlePrevClick = () => {
     if (currentIndex > 0) {

--- a/front-end/src/components/Details/Content/RelatedProduct/index.jsx
+++ b/front-end/src/components/Details/Content/RelatedProduct/index.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
 import axios from "axios";
-
 import { BsChevronLeft } from "react-icons/bs";
 import { BsChevronRight } from "react-icons/bs";
 import * as S from "./index.styled";

--- a/front-end/src/components/Details/Order/Button/DeliveryButton/index.jsx
+++ b/front-end/src/components/Details/Order/Button/DeliveryButton/index.jsx
@@ -24,12 +24,14 @@ function DeliveryButton() {
         container={ref}
         containerPadding={20}
       >
+        <S.StyledPopover>
         <Popover id="popover-contained">
                  <S.Text>
-                   <strong>택배배송</strong><br/> 무료배송 / 18시 이전 주문 시 오늘 출고 예정<br/>
+                   <strong>택배배송</strong><br/> 50000원 이상 구매 시 무료배송 / 18시 이전 주문 시 오늘 출고 예정<br/>
                   <strong>매장픽업</strong><br/> 온라인 구매 후 지정 매장에서 수령
                 </S.Text>
         </Popover>
+        </S.StyledPopover>
       </Overlay>
     </div>
   );

--- a/front-end/src/components/Details/Order/Button/DeliveryButton/index.jsx
+++ b/front-end/src/components/Details/Order/Button/DeliveryButton/index.jsx
@@ -26,10 +26,10 @@ function DeliveryButton() {
       >
         <S.StyledPopover>
         <Popover id="popover-contained">
-                 <S.Text>
+                 <S.PopoverText>
                    <strong>택배배송</strong><br/> 50000원 이상 구매 시 무료배송 / 18시 이전 주문 시 오늘 출고 예정<br/>
                   <strong>매장픽업</strong><br/> 온라인 구매 후 지정 매장에서 수령
-                </S.Text>
+                </S.PopoverText>
         </Popover>
         </S.StyledPopover>
       </Overlay>

--- a/front-end/src/components/Details/Order/Button/DeliveryButton/index.styled.js
+++ b/front-end/src/components/Details/Order/Button/DeliveryButton/index.styled.js
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import Popover from "react-bootstrap/Popover";
 
 const Button = styled.button`
   background-color: white;
@@ -13,7 +12,6 @@ const Button = styled.button`
 
 const Text = styled.div`
   font-size: 12px;
-  // padding: 10px 10px;
 `;
 
 const StyledPopover = styled.div`

--- a/front-end/src/components/Details/Order/Button/DeliveryButton/index.styled.js
+++ b/front-end/src/components/Details/Order/Button/DeliveryButton/index.styled.js
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import Popover from "react-bootstrap/Popover";
 
 const Button = styled.button`
   background-color: white;
@@ -12,7 +13,14 @@ const Button = styled.button`
 
 const Text = styled.div`
   font-size: 12px;
-  padding: 10px 10px;
+  // padding: 10px 10px;
 `;
 
-export { Button, Text };
+const StyledPopover = styled.div`
+  .popover {
+    max-width: 600px;
+    padding: 0px 10px 10px 10px;
+  }
+`;
+
+export { Button, Text, StyledPopover };

--- a/front-end/src/components/Details/Order/Button/DeliveryButton/index.styled.js
+++ b/front-end/src/components/Details/Order/Button/DeliveryButton/index.styled.js
@@ -1,16 +1,13 @@
 import styled from "@emotion/styled";
 
 const Button = styled.button`
-  background-color: white;
-  color: black;
-  font-size: 15px;
   padding: 10px;
   margin: 0 23px;
-  cursor: pointer;
   border: none;
+  background-color: white;
 `;
 
-const Text = styled.div`
+const PopoverText = styled.div`
   font-size: 12px;
 `;
 
@@ -21,4 +18,4 @@ const StyledPopover = styled.div`
   }
 `;
 
-export { Button, Text, StyledPopover };
+export { Button, PopoverText, StyledPopover };

--- a/front-end/src/components/Details/Order/Button/StockButton/index.jsx
+++ b/front-end/src/components/Details/Order/Button/StockButton/index.jsx
@@ -9,7 +9,7 @@ function StockButton({ stock }) {
   return (
     <S.Container>
       <S.Button className="btn" variant="outline-primary" onMouseOver={handleMouseOver} onMouseOut={handleMouseOut}>
-        재고 상태
+        <S.Text>재고 상태</S.Text>
       </S.Button>
       {show && stock >= 5 && <S.MessageBox>현재 재고는 {stock}개 입니다.</S.MessageBox>}
       {show && stock < 5 && <S.MessageBox>현재 재고는 5개 미만입니다.</S.MessageBox>}

--- a/front-end/src/components/Details/Order/Button/StockButton/index.styled.js
+++ b/front-end/src/components/Details/Order/Button/StockButton/index.styled.js
@@ -13,20 +13,10 @@ const Button = styled.button`
   cursor: pointer;
 `;
 
-const CloseButton = styled.button`
-  background-color: #e5cdce;
-  color: white;
-  font-size: 20px;
-  padding: 10px 60px;
-  border-style: none;
-  margin: 10px 40px;
-  cursor: pointer;
-`;
-
 const MessageBox = styled.div`
   background-color: #ede3d7;
   padding: 7px 10px;
   border-radius: 5px;
 `;
 
-export { Container, Button, CloseButton, MessageBox };
+export { Container, Button, MessageBox };

--- a/front-end/src/components/Details/Order/Button/StockButton/index.styled.js
+++ b/front-end/src/components/Details/Order/Button/StockButton/index.styled.js
@@ -5,12 +5,14 @@ const Container = styled.div`
 `;
 
 const Button = styled.button`
-  background-color: white;
-  color: black;
-  font-size: 15px;
   padding: 10px;
   margin: 0 20px;
-  cursor: pointer;
+  &:hover {
+    border: none;
+  }
+`;
+const Text = styled.div`
+  color: black;
 `;
 
 const MessageBox = styled.div`
@@ -19,4 +21,4 @@ const MessageBox = styled.div`
   border-radius: 5px;
 `;
 
-export { Container, Button, MessageBox };
+export { Container, Button, MessageBox, Text };


### PR DESCRIPTION
# 개요

#81
상품 상세페이지의 UI를 수정하였습니다.

## 한 일

- [X] 연관 상품 carousel로 화면에 나타나는 상품의 개수 4개 -> 3개 수정
- [x] 배송 방법 클릭 시 툴팁 문구 수정
- [x] 사용하지 않는 스타일 삭제
- [x] 재고 상태, 배송 방법 버튼 글씨 크기 통일

## ETC

carousel의 상품이 4개인 경우

![화면 캡처 2023-04-03 093859](https://user-images.githubusercontent.com/119832853/229388968-e0da4c38-453b-47b7-a39b-03004551a59b.png)

carousel의 상품이 3개인 경우
![image](https://user-images.githubusercontent.com/119832853/229389053-040875a8-d2cc-4cb6-a840-b97492ae71e6.png)
