### PR TITLE
[FE] 잘못된 상품 상세 페이지 접근시 404 에러 처리

### DIFF
--- a/front-end/src/components/My/Profile/ChangeForm/index.jsx
+++ b/front-end/src/components/My/Profile/ChangeForm/index.jsx
@@ -5,14 +5,12 @@ import { useRecoilValue } from "recoil";
 import { TextField, Button } from "@mui/material";
 import * as S from "./index.styled";
 
-import { API_PATH, BROWSER_PATH } from "../../../../constants/path";
+import { API_PATH } from "../../../../constants/path";
 import { CLIENT_ERROR_MESSAGE } from "../../../../constants/message";
 import { MEMBER_RULE } from "../../../../constants/rule";
 import { jwtToken } from "../../../../stores/auth";
-import { useNavigate } from "react-router-dom";
 
 function PasswordForm() {
-  const navigate = useNavigate();
   const token = useRecoilValue(jwtToken);
   const [nowPassword, setNowPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");

--- a/front-end/src/constants/path.js
+++ b/front-end/src/constants/path.js
@@ -9,6 +9,7 @@ const BROWSER_PATH = {
   PRODUCT: "/product",
   REVIEW: "/review",
   REVIEW_FORM: "/review-form",
+  NOT_FOUND: "/notfound",
 };
 
 // TODO: 추후 스프링과 연동하기

--- a/front-end/src/pages/Details/index.jsx
+++ b/front-end/src/pages/Details/index.jsx
@@ -1,13 +1,14 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import axios from "axios";
 
-import { API_PATH } from "../../constants/path";
+import { API_PATH, BROWSER_PATH } from "../../constants/path";
 
 import Loading from "../../components/Loading";
 import Detail from "../../components/Details";
 
 function Details() {
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState([]);
   const param = useParams();
@@ -21,9 +22,12 @@ function Details() {
         setLoading(false);
       })
       .catch((error) => {
+        if (error.response.status === 400) {
+          return navigate(BROWSER_PATH.NOT_FOUND, { replace: true });
+        }
         console.error(error);
       });
-  }, [param]);
+  }, [param, navigate]);
 
   useEffect(() => {
     getDataRequest();


### PR DESCRIPTION
# 개요

#106 

## 한 일

- `axios` 400 에러일 경우 `useNavigate`를 사용하여 `NotFound` 호출

## ETC

![404](https://user-images.githubusercontent.com/74192619/229569606-b27a2db1-0f8a-4956-8f03-3506605bf7bd.gif)

